### PR TITLE
Geo chevrons for proper representation of travels

### DIFF
--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import { FeatureGroup, LayerGroup, Polyline, Marker } from 'react-leaflet'
+import { FeatureGroup, Polyline, Marker } from 'react-leaflet'
 import L from 'leaflet'
 import ui from 'redux-ui'
 
@@ -88,7 +88,8 @@ export default class GeoEdges extends React.Component {
       onUnfocusElement
      } = this.props
 
-  const edges = this.props.edges.map( (e,i) => {
+    const children = []
+    this.props.edges.forEach( (e,i) => {
       const color = e.selected ? 'yellow' : (e.data.color ? e.data.color : 'purple')
       const weight = e.data.weight ? (e.data.weight > 6 ? 20 : Math.pow(e.data.weight,2)) : 1
       const dashArray = e.data.group ? (
@@ -100,12 +101,9 @@ export default class GeoEdges extends React.Component {
       ) : ""
 
       const { segments, chevrons } = this.buildSegmentsAndChevrons(e.coords, color, e.selected)
-      const hasChildren = (segments && segments.length) || (chevrons && chevrons.length)
-      if (!hasChildren) return null
-
-      return (
-        <LayerGroup key={`edge-${i}`}>
-          {segments.map((seg, sIdx) => (
+      if (segments && segments.length) {
+        segments.forEach((seg, sIdx) => {
+          children.push(
             <Polyline
               key={`edge-${i}-seg-${sIdx}`}
               opacity={"0.8"}
@@ -113,30 +111,31 @@ export default class GeoEdges extends React.Component {
               weight={weight}
               dashArray={dashArray}
               positions={seg}
-              onClick={() => !isolateMode ?
-                handleClickGeoElement({ group : 'edge', el: e })
-                : null
-              }
+              onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
               onMouseDown={() => isolateMode ? onFocusElement(e) : null }
               onMouseUp={()=> isolateMode ? onUnfocusElement() : null }
             />
-          ))}
-          {chevrons.map(ch => (
+          )
+        })
+      }
+      if (chevrons && chevrons.length) {
+        chevrons.forEach((ch, cIdx) => {
+          children.push(
             <Marker
-              key={ch.key}
+              key={`${ch.key}-${i}-${cIdx}`}
               position={ch.position}
               icon={ch.icon}
               interactive={false}
             />
-          ))}
-        </LayerGroup>
-      )
-  }).filter(Boolean)
+          )
+        })
+      }
+    })
 
     return (
       <FeatureGroup name="GeoEdges"
         ref="edgesGroup">
-        {edges}
+        {children}
       </FeatureGroup>
     )
   }

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -80,7 +80,7 @@ export default class GeoEdges extends React.Component {
       className: 'geo-chevron',
       html: `<span class="chev" style="color:${col}; border-color:${col};">
                <b>${g}</b>
-               <em class="chev-n">${label != null ? label : ''}</em>
+               <em class="chev-n" style="color:#000;">${label != null ? label : ''}</em>
              </span>`,
       iconSize: [0, 0]
     })

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -76,15 +76,18 @@ export default class GeoEdges extends React.Component {
 
     // Chevron glyph and placement at both seams
     const glyph = dirSign > 0 ? '\u00BB' /* » eastward */ : '\u00AB' /* « westward */
-    const makeIcon = (g, col) => L.divIcon({
+    const makeIcon = (g, col, label) => L.divIcon({
       className: 'geo-chevron',
-      html: `<span style="color:${col}; border-color:${col};">${g}</span>`,
+      html: `<span class="chev" style="color:${col}; border-color:${col};">
+               <b>${g}</b>
+               <em class="chev-n">${label != null ? label : ''}</em>
+             </span>`,
       iconSize: [0, 0]
     })
 
     const chevrons = [
-      { position: seamA, icon: makeIcon(glyph, color), key: `chev-a-${latInt}-${boundaryLng}` },
-      { position: seamB, icon: makeIcon(glyph, color), key: `chev-b-${latInt}-${otherBoundaryLng}` }
+      { position: seamA, icon: makeIcon(glyph, color, 1), key: `chev-a-${latInt}-${boundaryLng}` },
+      { position: seamB, icon: makeIcon(glyph, color, 2), key: `chev-b-${latInt}-${otherBoundaryLng}` }
     ]
 
     return { segments, chevrons }
@@ -120,6 +123,20 @@ export default class GeoEdges extends React.Component {
               color={color}
               weight={weight}
               dashArray={dashArray}
+              positions={seg}
+              onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
+              onMouseDown={() => isolateMode ? onFocusElement(e) : null }
+              onMouseUp={()=> isolateMode ? onUnfocusElement() : null }
+            />
+          )
+          // Invisible hit area: larger weight, nearly transparent
+          const hitWeight = Math.max(weight, 24)
+          children.push(
+            <Polyline
+              key={`edge-${i}-seg-${sIdx}-hit`}
+              opacity={0.001}
+              color={color}
+              weight={hitWeight}
               positions={seg}
               onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
               onMouseDown={() => isolateMode ? onFocusElement(e) : null }

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -3,7 +3,7 @@ import { FeatureGroup, Polyline, Marker } from 'react-leaflet'
 import L from 'leaflet'
 import ui from 'redux-ui'
 
-@ui()
+@ui({ key: 'PanelSettings' })
 export default class GeoEdges extends React.Component {
   static propTypes = {
     edges : PropTypes.array.isRequired,

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -78,9 +78,8 @@ export default class GeoEdges extends React.Component {
     const glyph = dirSign > 0 ? '\u00BB' /* » eastward */ : '\u00AB' /* « westward */
     const makeIcon = (g, col, label) => L.divIcon({
       className: 'geo-chevron',
-      html: `<span class="chev" style="color:${col}; border-color:${col};">
-               <b>${g}</b>
-               <em class="chev-n" style="color:#000;">${label != null ? label : ''}</em>
+      html: `<span class="chev" style="color:${col}; border-color:${col}; white-space:nowrap; display:inline-flex; align-items:center;">
+               <b>${g}</b>&nbsp;<em class="chev-n" style="color:#000;">${label != null ? label : ''}</em>
              </span>`,
       iconSize: [0, 0]
     })

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
-import { FeatureGroup, Polyline } from 'react-leaflet'
+import { FeatureGroup, Polyline, Marker } from 'react-leaflet'
+import L from 'leaflet'
 import ui from 'redux-ui'
 
 @ui()
@@ -12,6 +13,64 @@ export default class GeoEdges extends React.Component {
     onUnfocusElement : PropTypes.func.isRequired
   }
 
+  // Return segments and chevrons for an edge, splitting at the antimeridian when needed
+  buildSegmentsAndChevrons(coords, color, selected) {
+    if (!coords || coords.length !== 2) return { segments: [coords], chevrons: [] }
+    let [[lat1, lng1], [lat2, lng2]] = coords
+
+    // Normalize longitudes into [-180, 180]
+    const norm = lng => {
+      let x = lng
+      while (x > 180) x -= 360
+      while (x < -180) x += 360
+      return x
+    }
+    lng1 = norm(lng1); lng2 = norm(lng2)
+
+    const delta = lng2 - lng1
+
+    // No split if shortest longitudinal delta is within [-180, 180]
+    if (Math.abs(delta) <= 180) {
+      return { segments: [ [[lat1, lng1], [lat2, lng2]] ], chevrons: [] }
+    }
+
+    // We cross the dateline: choose which meridian we hit first (±180)
+    const boundaryLng = delta > 0 ? 180 : -180
+    const otherBoundaryLng = boundaryLng === 180 ? -180 : 180
+
+    // Linear interpolation in lon/lat space to find intersection lat at boundaryLng
+    const denom = (lng2 - lng1)
+    if (!denom) {
+      return { segments: [ [[lat1, lng1], [lat2, lng2]] ], chevrons: [] }
+    }
+    const t = (boundaryLng - lng1) / denom
+    const latInt = lat1 + t * (lat2 - lat1)
+
+    const seamA = [latInt, boundaryLng]
+    const seamB = [latInt, otherBoundaryLng]
+
+    // Two segments: start -> seamA, seamB -> end
+    const segments = [
+      [[lat1, lng1], seamA],
+      [seamB, [lat2, lng2]]
+    ]
+
+    // Chevron glyph and placement at both seams
+    const glyph = delta > 0 ? '\u00BB' /* » eastward */ : '\u00AB' /* « westward */
+    const makeIcon = (g) => L.divIcon({
+      className: 'geo-chevron',
+      html: `<span>${g}</span>`,
+      iconSize: [0, 0]
+    })
+
+    const chevrons = [
+      { position: seamA, icon: makeIcon(glyph), key: `chev-a-${latInt}-${boundaryLng}` },
+      { position: seamB, icon: makeIcon(glyph), key: `chev-b-${latInt}-${otherBoundaryLng}` }
+    ]
+
+    return { segments, chevrons }
+  }
+
   render() {
     const {
       isolateMode,
@@ -21,46 +80,47 @@ export default class GeoEdges extends React.Component {
      } = this.props
 
     const edges = this.props.edges.map( (e,i) => {
+      const color = e.selected ? 'yellow' : (e.data.color ? e.data.color : 'purple')
+      const weight = e.data.weight ? (e.data.weight > 6 ? 20 : Math.pow(e.data.weight,2)) : 1
+      const dashArray = e.data.group ? (
+        e.data.group.includes("DASHED2")?"5,2":
+        e.data.group.includes("DASHED1")?"5,4":
+        e.data.group.includes("DASHED-2")?"5,2,2,5,2,2,5":
+        e.data.group.includes("DASHED-1")? "1,5,1,5,1":
+        ""
+      ) : ""
+
+      const { segments, chevrons } = this.buildSegmentsAndChevrons(e.coords, color, e.selected)
+
       return (
-        <Polyline
-          key={`edge-${i}`}
-          opacity={"0.8"}
-          color={e.selected ? 'yellow' : e.data.color ? e.data.color : 'purple'}
-          //LIMIT THE EDGES MAX WIDTH
-          weight={e.data.weight?e.data.weight > 6 ? 20 : Math.pow(e.data.weight,2):1}
-          dashArray= {e.data.group?
-             (
-               e.data.group.includes("DASHED2")?"5,2":
-               e.data.group.includes("DASHED1")?"5,4":
-               e.data.group.includes("DASHED-2")?"5,2,2,5,2,2,5":
-               e.data.group.includes("DASHED-1")? "1,5,1,5,1":
-               ""
-             )
-             :""
-           }
-          positions={e.coords}
-          onClick={() => !isolateMode ?
-            handleClickGeoElement({
-              group : 'edge',
-              el: e
-            })
-            :
-            null
-          }
-          onMouseDown={() => isolateMode ?
-            onFocusElement(e)
-            :
-            null
-          }
-          onMouseUp={()=> isolateMode ?
-            onUnfocusElement()
-            :
-            null
-          }
-        />
+        <FeatureGroup key={`edge-${i}`}>
+          {segments.map((seg, sIdx) => (
+            <Polyline
+              key={`edge-${i}-seg-${sIdx}`}
+              opacity={"0.8"}
+              color={color}
+              weight={weight}
+              dashArray={dashArray}
+              positions={seg}
+              onClick={() => !isolateMode ?
+                handleClickGeoElement({ group : 'edge', el: e })
+                : null
+              }
+              onMouseDown={() => isolateMode ? onFocusElement(e) : null }
+              onMouseUp={()=> isolateMode ? onUnfocusElement() : null }
+            />
+          ))}
+          {chevrons.map(ch => (
+            <Marker
+              key={ch.key}
+              position={ch.position}
+              icon={ch.icon}
+              interactive={false}
+            />
+          ))}
+        </FeatureGroup>
       )
-    }
-    )
+    })
 
     return (
       <FeatureGroup name="GeoEdges"

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -158,7 +158,7 @@ export default class GeoEdges extends React.Component {
           )
         })
       }
-      const showChevrons = (this.props.ui && this.props.ui.showChevrons !== false)
+  const showChevrons = !this.props.ui || this.props.ui.showChevrons !== false
       if (showChevrons && chevrons && chevrons.length) {
         chevrons.forEach((ch, cIdx) => {
           let lat = parseFloat(ch.position[0])

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -114,7 +114,8 @@ export default class GeoEdges extends React.Component {
       onUnfocusElement
      } = this.props
 
-    const children = []
+  const children = []
+    const isChevronsOn = (!this.props.ui || this.props.ui.showChevrons !== false)
     const seamSlots = { '180': new Map(), '-180': new Map() }
     const getOffsetLat = (boundary, lat) => {
       const key = boundary === 180 ? '180' : '-180'
@@ -129,7 +130,7 @@ export default class GeoEdges extends React.Component {
       return offset
     }
     // Decide behavior per toggle: when chevrons are off, draw direct single segments
-    this.props.edges.forEach( (e,i) => {
+  this.props.edges.forEach( (e,i) => {
       const label = i + 1
       const color = e.selected ? 'yellow' : (e.data.color ? e.data.color : 'purple')
       const weight = e.data.weight ? (e.data.weight > 6 ? 20 : Math.pow(e.data.weight,2)) : 1
@@ -141,7 +142,7 @@ export default class GeoEdges extends React.Component {
         ""
       ) : ""
       // Read UI toggle once per edge to drive splitting behavior
-      const showChevrons = !this.props.ui || this.props.ui.showChevrons !== false
+  const showChevrons = isChevronsOn
       let segments = []
       let chevrons = []
       if (showChevrons) {
@@ -163,7 +164,7 @@ export default class GeoEdges extends React.Component {
         segments.forEach((seg, sIdx) => {
           children.push(
             <Polyline
-              key={`edge-${i}-seg-${sIdx}`}
+              key={`edge-${i}-seg-${sIdx}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
               opacity={"0.8"}
               color={color}
               weight={weight}
@@ -178,7 +179,7 @@ export default class GeoEdges extends React.Component {
           const hitWeight = Math.max(weight, 24)
           children.push(
             <Polyline
-              key={`edge-${i}-seg-${sIdx}-hit`}
+              key={`edge-${i}-seg-${sIdx}-hit-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
               opacity={0.001}
               color={color}
               weight={hitWeight}
@@ -191,8 +192,7 @@ export default class GeoEdges extends React.Component {
         })
       }
       // Only render chevrons when enabled
-      const showChevronsRender = !this.props.ui || this.props.ui.showChevrons !== false
-      if (showChevronsRender && chevrons && chevrons.length) {
+      if (isChevronsOn && chevrons && chevrons.length) {
         chevrons.forEach((ch, cIdx) => {
           let lat = parseFloat(ch.position[0])
           let lng = parseFloat(ch.position[1])
@@ -204,7 +204,7 @@ export default class GeoEdges extends React.Component {
           }
           children.push(
             <Marker
-              key={`${ch.key}-${i}-${cIdx}`}
+              key={`${ch.key}-${i}-${cIdx}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
               position={[lat, lng]}
               icon={ch.icon}
               interactive={true}
@@ -215,7 +215,7 @@ export default class GeoEdges extends React.Component {
       }
     })
 
-    const uiKey = (!this.props.ui || this.props.ui.showChevrons !== false) ? 'with-chevrons' : 'no-chevrons'
+  const uiKey = isChevronsOn ? 'with-chevrons' : 'no-chevrons'
     return (
       <FeatureGroup name="GeoEdges"
         key={`edges-${uiKey}`}

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -15,7 +15,26 @@ export default class GeoEdges extends React.Component {
 
   componentDidMount() {
     if (typeof window !== 'undefined') {
-      this._onShowChevronsChanged = () => this.forceUpdate()
+      // Initialize local chevron state from storage or props
+      try {
+        const ls = window.localStorage ? window.localStorage.getItem('topo.showChevrons') : null
+        if (ls !== null) {
+          this.setState({ chevronsOn: JSON.parse(ls) })
+        }
+      } catch (e) {}
+      this._onShowChevronsChanged = (evt) => {
+        const val = evt && evt.detail && typeof evt.detail.value === 'boolean' ? evt.detail.value : undefined
+        if (typeof val === 'boolean') {
+          this.setState({ chevronsOn: val })
+        } else {
+          // Fallback, read from storage
+          try {
+            const ls = window.localStorage ? window.localStorage.getItem('topo.showChevrons') : null
+            if (ls !== null) this.setState({ chevronsOn: JSON.parse(ls) })
+            else this.forceUpdate()
+          } catch (e) { this.forceUpdate() }
+        }
+      }
       window.addEventListener('topo:showChevronsChanged', this._onShowChevronsChanged)
     }
   }
@@ -114,8 +133,10 @@ export default class GeoEdges extends React.Component {
       onUnfocusElement
      } = this.props
 
-  const children = []
-    const isChevronsOn = (!this.props.ui || this.props.ui.showChevrons !== false)
+    const children = []
+    const isChevronsOn = (this.state && typeof this.state.chevronsOn === 'boolean')
+      ? this.state.chevronsOn
+      : (!this.props.ui || this.props.ui.showChevrons !== false)
     const seamSlots = { '180': new Map(), '-180': new Map() }
     const getOffsetLat = (boundary, lat) => {
       const key = boundary === 180 ? '180' : '-180'

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -13,6 +13,20 @@ export default class GeoEdges extends React.Component {
     onUnfocusElement : PropTypes.func.isRequired
   }
 
+  componentDidMount() {
+    if (typeof window !== 'undefined') {
+      this._onShowChevronsChanged = () => this.forceUpdate()
+      window.addEventListener('topo:showChevronsChanged', this._onShowChevronsChanged)
+    }
+  }
+
+  componentWillUnmount() {
+    if (typeof window !== 'undefined' && this._onShowChevronsChanged) {
+      window.removeEventListener('topo:showChevronsChanged', this._onShowChevronsChanged)
+      this._onShowChevronsChanged = null
+    }
+  }
+
   // Return segments and chevrons for an edge, splitting at the antimeridian when needed
   buildSegmentsAndChevrons(coords, color, selected, label) {
     if (!coords || coords.length !== 2) return { segments: [], chevrons: [] }

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -88,7 +88,7 @@ export default class GeoEdges extends React.Component {
       onUnfocusElement
      } = this.props
 
-    const edges = this.props.edges.map( (e,i) => {
+  const edges = this.props.edges.map( (e,i) => {
       const color = e.selected ? 'yellow' : (e.data.color ? e.data.color : 'purple')
       const weight = e.data.weight ? (e.data.weight > 6 ? 20 : Math.pow(e.data.weight,2)) : 1
       const dashArray = e.data.group ? (
@@ -100,6 +100,8 @@ export default class GeoEdges extends React.Component {
       ) : ""
 
       const { segments, chevrons } = this.buildSegmentsAndChevrons(e.coords, color, e.selected)
+      const hasChildren = (segments && segments.length) || (chevrons && chevrons.length)
+      if (!hasChildren) return null
 
       return (
         <LayerGroup key={`edge-${i}`}>
@@ -129,7 +131,7 @@ export default class GeoEdges extends React.Component {
           ))}
         </LayerGroup>
       )
-    })
+  }).filter(Boolean)
 
     return (
       <FeatureGroup name="GeoEdges"

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -111,8 +111,8 @@ export default class GeoEdges extends React.Component {
     const glyph = dirSign > 0 ? '\u00BB' /* » eastward */ : '\u00AB' /* « westward */
     const makeIcon = (g, col, label) => L.divIcon({
       className: 'geo-chevron',
-      html: `<span class="chev" style="color:${col}; border-color:${col}; white-space:nowrap; display:inline-flex; align-items:center;">
-               <b>${g}</b>&nbsp;<em class="chev-n" style="color:#000;">${label != null ? label : ''}</em>
+      html: `<span class="chev" style="color:${col}; border-color:${col}; white-space:nowrap; display:inline-flex; align-items:center; gap:2px;">
+               <b style="line-height:1">${g}</b><em class="chev-n" style="color:#000; line-height:1;">${label != null ? label : ''}</em>
              </span>`,
       iconSize: [0, 0]
     })

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -17,6 +17,8 @@ export default class GeoEdges extends React.Component {
   buildSegmentsAndChevrons(coords, color, selected) {
     if (!coords || coords.length !== 2) return { segments: [], chevrons: [] }
     let [[lat1, lng1], [lat2, lng2]] = coords
+    lat1 = parseFloat(lat1); lng1 = parseFloat(lng1)
+    lat2 = parseFloat(lat2); lng2 = parseFloat(lng2)
 
     // Normalize longitudes into [-180, 180]
     const norm = lng => {
@@ -30,7 +32,7 @@ export default class GeoEdges extends React.Component {
     const delta = lng2 - lng1
 
     // No split if shortest longitudinal delta is within [-180, 180]
-    if (isNaN(lat1) || isNaN(lng1) || isNaN(lat2) || isNaN(lng2)) {
+    if (!isFinite(lat1) || !isFinite(lng1) || !isFinite(lat2) || !isFinite(lng2)) {
       return { segments: [], chevrons: [] }
     }
     if (Math.abs(delta) <= 180) {
@@ -57,6 +59,9 @@ export default class GeoEdges extends React.Component {
 
     const seamA = [latInt, boundaryLng]
     const seamB = [latInt, otherBoundaryLng]
+    if (!isFinite(seamA[0]) || !isFinite(seamA[1]) || !isFinite(seamB[0]) || !isFinite(seamB[1])) {
+      return { segments: [ [[lat1, lng1], [lat2, lng2]] ], chevrons: [] }
+    }
 
     // Two segments: start -> seamA, seamB -> end
     const segments = [

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -116,6 +116,7 @@ export default class GeoEdges extends React.Component {
               weight={weight}
               dashArray={dashArray}
               positions={seg}
+              bubblingMouseEvents={false}
               onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
               onMouseDown={() => isolateMode ? onFocusElement(e) : null }
               onMouseUp={()=> isolateMode ? onUnfocusElement() : null }
@@ -125,10 +126,13 @@ export default class GeoEdges extends React.Component {
       }
       if (chevrons && chevrons.length) {
         chevrons.forEach((ch, cIdx) => {
+          const lat = parseFloat(ch.position[0])
+          const lng = parseFloat(ch.position[1])
+          if (!isFinite(lat) || !isFinite(lng)) return
           children.push(
             <Marker
               key={`${ch.key}-${i}-${cIdx}`}
-              position={ch.position}
+              position={[lat, lng]}
               icon={ch.icon}
               interactive={false}
             />

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -14,7 +14,7 @@ export default class GeoEdges extends React.Component {
   }
 
   // Return segments and chevrons for an edge, splitting at the antimeridian when needed
-  buildSegmentsAndChevrons(coords, color, selected) {
+  buildSegmentsAndChevrons(coords, color, selected, label) {
     if (!coords || coords.length !== 2) return { segments: [], chevrons: [] }
     let [[lat1, lng1], [lat2, lng2]] = coords
     lat1 = parseFloat(lat1); lng1 = parseFloat(lng1)
@@ -86,8 +86,8 @@ export default class GeoEdges extends React.Component {
     })
 
     const chevrons = [
-      { position: seamA, icon: makeIcon(glyph, color, 1), key: `chev-a-${latInt}-${boundaryLng}` },
-      { position: seamB, icon: makeIcon(glyph, color, 2), key: `chev-b-${latInt}-${otherBoundaryLng}` }
+      { position: seamA, icon: makeIcon(glyph, color, label), key: `chev-a-${latInt}-${boundaryLng}` },
+      { position: seamB, icon: makeIcon(glyph, color, label), key: `chev-b-${latInt}-${otherBoundaryLng}` }
     ]
 
     return { segments, chevrons }
@@ -103,6 +103,7 @@ export default class GeoEdges extends React.Component {
 
     const children = []
     this.props.edges.forEach( (e,i) => {
+      const label = i + 1
       const color = e.selected ? 'yellow' : (e.data.color ? e.data.color : 'purple')
       const weight = e.data.weight ? (e.data.weight > 6 ? 20 : Math.pow(e.data.weight,2)) : 1
       const dashArray = e.data.group ? (
@@ -113,7 +114,7 @@ export default class GeoEdges extends React.Component {
         ""
       ) : ""
 
-      const { segments, chevrons } = this.buildSegmentsAndChevrons(e.coords, color, e.selected)
+  const { segments, chevrons } = this.buildSegmentsAndChevrons(e.coords, color, e.selected, label)
       if (segments && segments.length) {
         segments.forEach((seg, sIdx) => {
           children.push(

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -45,14 +45,13 @@ export default class GeoEdges extends React.Component {
     const dirSign = wrappedDelta >= 0 ? 1 : -1
     // Distance along chosen direction from a to b on circle
     const distAlong = (a, b, sign) => sign > 0 ? ((b - a + 360) % 360) : ((a - b + 360) % 360)
-    const dTo180 = distAlong(lng1, 180, dirSign)
-    const dToNeg180 = distAlong(lng1, -180, dirSign)
-    const boundaryLng = dTo180 <= dToNeg180 ? 180 : -180
-    const otherBoundaryLng = boundaryLng === 180 ? -180 : 180
+  // Boundary is determined by wrapped direction: east crosses +180, west crosses -180
+  const boundaryLng = dirSign > 0 ? 180 : -180
+  const otherBoundaryLng = boundaryLng === 180 ? -180 : 180
 
     // Fraction to reach the seam along the wrapped path
     const total = Math.abs(wrappedDelta) // in (0, 180]
-    const toSeam = distAlong(lng1, boundaryLng, dirSign)
+  const toSeam = distAlong(lng1, boundaryLng, dirSign)
     let t = total > 0 ? (toSeam / total) : 0
     if (!isFinite(t)) t = 0
     if (t < 0) t = 0
@@ -76,16 +75,16 @@ export default class GeoEdges extends React.Component {
     ]
 
     // Chevron glyph and placement at both seams
-  const glyph = dirSign > 0 ? '\u00BB' /* » eastward */ : '\u00AB' /* « westward */
-    const makeIcon = (g) => L.divIcon({
+    const glyph = dirSign > 0 ? '\u00BB' /* » eastward */ : '\u00AB' /* « westward */
+    const makeIcon = (g, col) => L.divIcon({
       className: 'geo-chevron',
-      html: `<span>${g}</span>`,
+      html: `<span style="color:${col}; border-color:${col};">${g}</span>`,
       iconSize: [0, 0]
     })
 
     const chevrons = [
-      { position: seamA, icon: makeIcon(glyph), key: `chev-a-${latInt}-${boundaryLng}` },
-      { position: seamB, icon: makeIcon(glyph), key: `chev-b-${latInt}-${otherBoundaryLng}` }
+      { position: seamA, icon: makeIcon(glyph, color), key: `chev-a-${latInt}-${boundaryLng}` },
+      { position: seamB, icon: makeIcon(glyph, color), key: `chev-b-${latInt}-${otherBoundaryLng}` }
     ]
 
     return { segments, chevrons }
@@ -122,7 +121,6 @@ export default class GeoEdges extends React.Component {
               weight={weight}
               dashArray={dashArray}
               positions={seg}
-              bubblingMouseEvents={false}
               onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
               onMouseDown={() => isolateMode ? onFocusElement(e) : null }
               onMouseUp={()=> isolateMode ? onUnfocusElement() : null }
@@ -140,7 +138,8 @@ export default class GeoEdges extends React.Component {
               key={`${ch.key}-${i}-${cIdx}`}
               position={[lat, lng]}
               icon={ch.icon}
-              interactive={false}
+              interactive={true}
+              onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
             />
           )
         })

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -36,10 +36,11 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   transform: translate(-50%, -50%);
 }
 .geo-chevron .chev {
-  display: inline-block;
-  padding: 0 1px; /* less vertical/overall padding */
+  display: inline-flex; /* tighter inline layout */
+  align-items: center;
+  padding: 0 0.5px; /* trim padding to shrink box */
   border-radius: 2px;
-  font-size: 10px;
+  font-size: 11px; /* increase text size */
   font-weight: 700;
   color: #222;
   background: rgba(255, 255, 255, 0.85);
@@ -47,8 +48,10 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   box-shadow: 0 0.5px 1px rgba(0,0,0,0.12);
 }
 .geo-chevron .chev-n {
-  font-size: 8px;
+  font-size: 8.5px; /* slightly larger */
   font-style: normal;
-  margin-left: 3px;
+  margin-left: 2px;
+  line-height: 1;
+  letter-spacing: 0.1px;
   color: #000; /* enforced also inline in icon HTML */
 }

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -58,3 +58,11 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   color: #000; /* enforced also inline in icon HTML */
   margin-top: -0.5px; /* tiny upward nudge for better optical alignment */
 }
+
+/* Enlarge the chevron glyph without affecting box size */
+.geo-chevron .chev b {
+  display: inline-block;
+  line-height: 1;
+  transform: scale(1.25);
+  transform-origin: center;
+}

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -37,9 +37,9 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
 }
 .geo-chevron .chev {
   display: inline-block;
-  padding: 1px 3px;
+  padding: 0 2px;
   border-radius: 3px;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 700;
   color: #222;
   background: rgba(255, 255, 255, 0.85);
@@ -47,7 +47,7 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   box-shadow: 0 1px 2px rgba(0,0,0,0.15);
 }
 .geo-chevron .chev-n {
-  font-size: 9px;
+  font-size: 8.5px;
   font-style: normal;
   margin-left: 4px;
   color: #000; /* enforced also inline in icon HTML */

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -37,9 +37,9 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
 }
 .geo-chevron .chev {
   display: inline-block;
-  padding: 2px 4px;
+  padding: 1px 3px;
   border-radius: 3px;
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 700;
   color: #222;
   background: rgba(255, 255, 255, 0.85);
@@ -47,8 +47,8 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   box-shadow: 0 1px 2px rgba(0,0,0,0.15);
 }
 .geo-chevron .chev-n {
-  font-size: 10px;
+  font-size: 9px;
   font-style: normal;
   margin-left: 4px;
-  color: inherit;
+  color: #000; /* enforced also inline in icon HTML */
 }

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -35,7 +35,7 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   pointer-events: none;
   transform: translate(-50%, -50%);
 }
-.geo-chevron span {
+.geo-chevron .chev {
   display: inline-block;
   padding: 2px 4px;
   border-radius: 3px;
@@ -45,4 +45,10 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   background: rgba(255, 255, 255, 0.85);
   border: 1px solid rgba(0,0,0,0.2);
   box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+}
+.geo-chevron .chev-n {
+  font-size: 10px;
+  font-style: normal;
+  margin-left: 4px;
+  color: inherit;
 }

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -37,18 +37,18 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
 }
 .geo-chevron .chev {
   display: inline-block;
-  padding: 0 2px;
-  border-radius: 3px;
-  font-size: 11px;
+  padding: 0 1px; /* less vertical/overall padding */
+  border-radius: 2px;
+  font-size: 10px;
   font-weight: 700;
   color: #222;
   background: rgba(255, 255, 255, 0.85);
   border: 1px solid rgba(0,0,0,0.2);
-  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+  box-shadow: 0 0.5px 1px rgba(0,0,0,0.12);
 }
 .geo-chevron .chev-n {
-  font-size: 8.5px;
+  font-size: 8px;
   font-style: normal;
-  margin-left: 4px;
+  margin-left: 3px;
   color: #000; /* enforced also inline in icon HTML */
 }

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -29,3 +29,20 @@ a.leaflet-control-zoom-out{
 div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   float: left;
   }
+
+/* Small chevron markers indicating date-line crossing */
+.geo-chevron {
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+}
+.geo-chevron span {
+  display: inline-block;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #222;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(0,0,0,0.2);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+}

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -33,7 +33,8 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
 /* Small chevron markers indicating date-line crossing */
 .geo-chevron {
   pointer-events: none;
-  transform: translate(-50%, -50%);
+  /* Center on coordinate and nudge up 1px to align with edge */
+  transform: translate(-50%, -50%) translateY(-1px);
 }
 .geo-chevron .chev {
   display: inline-flex; /* tighter inline layout */
@@ -46,6 +47,7 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   background: rgba(255, 255, 255, 0.85);
   border: 1px solid rgba(0,0,0,0.2);
   box-shadow: 0 0.5px 1px rgba(0,0,0,0.12);
+  line-height: 1; /* minimize baseline offset */
 }
 .geo-chevron .chev-n {
   font-size: 8.5px; /* slightly larger */
@@ -54,4 +56,5 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   line-height: 1;
   letter-spacing: 0.1px;
   color: #000; /* enforced also inline in icon HTML */
+  margin-top: -0.5px; /* tiny upward nudge for better optical alignment */
 }

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -82,20 +82,26 @@ class GeoMap extends React.Component {
 
     const nodes = this.props.nodes
       .map( n => {
-        const coords = [n.data.lat,n.data.lng]
+        const lat = parseFloat(n.data.lat)
+        const lng = parseFloat(n.data.lng)
+        if (!isFinite(lat) || !isFinite(lng)) return null
+        const coords = [lat, lng]
         const node = { ...n, coords }
         nodesById[n.data.id] = node // store for edges
         return node
       })
+      .filter(Boolean)
 
     const edges = this.props.edges
       .map( e => {
-        const source = nodesById[e.data.source],
-          target = nodesById[e.data.target],
-          coords = [source.coords, target.coords],
-          selected = e.data.selected
+        const source = nodesById[e.data.source]
+        const target = nodesById[e.data.target]
+        if (!source || !target) return null
+        const coords = [source.coords, target.coords]
+        const selected = e.data.selected
         return { ...e, source, target, coords, selected }
       })
+      .filter(Boolean)
 
     const {
       url,

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -111,12 +111,14 @@ class GeoMap extends React.Component {
       ext
     } = mapTiles[geoMapTile]
 
+    const chevOn = (!this.props.ui || this.props.ui.showChevrons !== false)
     return (
       <div
         id={MAP_DIV_ID}
         style={Object.assign({}, divMapStyle,{ left, height })}
       >
         <Map
+          key={`map-${chevOn ? 'with' : 'no'}-chev`}
           center={position}
           zoom={zoom}
           zoomSnap= "0.01"

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -122,6 +122,7 @@ class GeoMap extends React.Component {
           zoomSnap= "0.01"
            zoomDelta= "0.05"
           zoomControl= {false}
+          doubleClickZoom={false}
 
 
           ref="map"

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -122,7 +122,6 @@ class GeoMap extends React.Component {
           zoomSnap= "0.01"
            zoomDelta= "0.05"
           zoomControl= {false}
-          doubleClickZoom={false}
 
 
           ref="map"

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -129,6 +129,7 @@ class GeoMap extends React.Component {
           {
             edges.length ?
               <GeoEdges
+                key={`geoedges-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
                 edges={edges}
                 isolateMode={isolateMode}
                 handleClickGeoElement={

--- a/imports/client/ui/components/panelSelector/PanelSelector.jsx
+++ b/imports/client/ui/components/panelSelector/PanelSelector.jsx
@@ -108,17 +108,17 @@ export default class PanelSelector extends React.Component {
             onClick={ () => this.toggleGeo()}
           />
         </MenuItem>
-        <MenuItem style={{...buttonStyle, paddingLeft: 48, paddingTop: 6, paddingBottom: 6}}>
+        <MenuItem style={{...buttonStyle, paddingLeft: 48, paddingTop: 2, paddingBottom: 2}}>
           <Checkbox
             label={'Chevrons'}
-            style={{ marginLeft: 0 }}
+            style={{ marginLeft: 0, marginTop: -4, marginBottom: -4 }}
             labelStyle={{
               backgroundColor: 'rgba(69,90,100 ,0.9)',
               color:'#F2EFE9',
-              fontSize: 12,
-              lineHeight: '16px'
+              fontSize: 11,
+              lineHeight: '14px'
             }}
-            iconStyle={{ transform: 'scale(0.85)', transformOrigin: 'left center' }}
+            iconStyle={{ transform: 'scale(0.8)', transformOrigin: 'left center' }}
             checked={showChevrons !== false}
             onClick={ () => this.toggleChevrons()}
           />

--- a/imports/client/ui/components/panelSelector/PanelSelector.jsx
+++ b/imports/client/ui/components/panelSelector/PanelSelector.jsx
@@ -13,7 +13,7 @@ const buttonStyle = {
   color:'#F2EFE9 !important'
 }
 
-@ui({ key: 'PanelSettings', state: { showChevrons: true } })
+@ui({ key: 'PanelSettings', state: { showChevrons: (typeof window !== 'undefined' && window.localStorage && window.localStorage.getItem('topo.showChevrons') !== null) ? JSON.parse(window.localStorage.getItem('topo.showChevrons')) : true } })
 export default class PanelSelector extends React.Component {
 
   static propTypes = {
@@ -37,7 +37,19 @@ export default class PanelSelector extends React.Component {
 
   toggleChevrons() {
     const cur = this.props.ui.showChevrons
-    this.props.updateUI('showChevrons', cur === false ? true : !cur)
+    const next = cur === false ? true : !cur
+    this.props.updateUI('showChevrons', next)
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem('topo.showChevrons', JSON.stringify(next))
+      }
+      if (typeof window !== 'undefined') {
+        const evt = new CustomEvent('topo:showChevronsChanged', { detail: { value: next } })
+        window.dispatchEvent(evt)
+      }
+    } catch (e) {
+      // no-op if storage unavailable
+    }
   }
 
 

--- a/imports/client/ui/components/panelSelector/PanelSelector.jsx
+++ b/imports/client/ui/components/panelSelector/PanelSelector.jsx
@@ -108,10 +108,10 @@ export default class PanelSelector extends React.Component {
             onClick={ () => this.toggleGeo()}
           />
         </MenuItem>
-        <MenuItem style={{...buttonStyle, paddingLeft: 48, paddingTop: 2, paddingBottom: 2}}>
+  <MenuItem style={{...buttonStyle, paddingLeft: 48, paddingTop: 0, paddingBottom: 0, marginBottom: -2}}>
           <Checkbox
             label={'Chevrons'}
-            style={{ marginLeft: 0, marginTop: -4, marginBottom: -4 }}
+            style={{ marginLeft: 0, marginTop: -6, marginBottom: -6 }}
             labelStyle={{
               backgroundColor: 'rgba(69,90,100 ,0.9)',
               color:'#F2EFE9',
@@ -123,7 +123,7 @@ export default class PanelSelector extends React.Component {
             onClick={ () => this.toggleChevrons()}
           />
         </MenuItem>
-        <MenuItem style={buttonStyle}>
+  <MenuItem style={{...buttonStyle, paddingTop: 0, marginTop: -2}}>
           <Checkbox
             label={'Time'}
             labelStyle={{backgroundColor: 'rgba(69,90,100 ,0.9)',

--- a/imports/client/ui/components/panelSelector/PanelSelector.jsx
+++ b/imports/client/ui/components/panelSelector/PanelSelector.jsx
@@ -35,6 +35,11 @@ export default class PanelSelector extends React.Component {
     this.props.updateUI( 'legendVisible', !this.props.ui.legendVisible )
   }
 
+  toggleChevrons() {
+    const cur = this.props.ui.showChevrons
+    this.props.updateUI('showChevrons', cur === false ? true : !cur)
+  }
+
 
 
   toggleGraph() {
@@ -55,7 +60,8 @@ export default class PanelSelector extends React.Component {
       geoMapVisible,
       graphVisible,
       chartsVisible,
-      legendVisible
+      legendVisible,
+      showChevrons
     } = this.props.ui
 
     const {
@@ -72,14 +78,12 @@ export default class PanelSelector extends React.Component {
         color:'#F2EFE9',}}
         >
         <MenuItem style={buttonStyle}>
-          <Checkbox style={{backgroundColor: 'rgba(69,90,100 ,0.9)',
-          color:'#F2EFE9',}}
+          <Checkbox
             label={ 'Graph'}
             labelStyle={{backgroundColor: 'rgba(69,90,100 ,0.9)',
             color:'#F2EFE9',}}
             checked={graphVisible}
             onClick={ () => this.toggleGraph()}
-            style={{fill : '#D3E8E6 !important' }}
           />
         </MenuItem>
         <MenuItem style={buttonStyle}>
@@ -90,6 +94,15 @@ export default class PanelSelector extends React.Component {
             checked={geoMapVisible}
             disabled={!hasGeoInfo}
             onClick={ () => this.toggleGeo()}
+          />
+        </MenuItem>
+        <MenuItem style={buttonStyle}>
+          <Checkbox
+            label={'Chevrons'}
+            labelStyle={{backgroundColor: 'rgba(69,90,100 ,0.9)',
+            color:'#F2EFE9',}}
+            checked={showChevrons !== false}
+            onClick={ () => this.toggleChevrons()}
           />
         </MenuItem>
         <MenuItem style={buttonStyle}>
@@ -120,6 +133,15 @@ export default class PanelSelector extends React.Component {
             checked={legendVisible}
             //disabled={!legendVisible}
             onClick={ () => this.toggleLegend()}
+          />
+        </MenuItem>
+        <MenuItem style={buttonStyle}>
+          <Checkbox
+            label={'Chevrons'}
+            labelStyle={{backgroundColor: 'rgba(69,90,100 ,0.9)',
+            color:'#F2EFE9',}}
+            checked={showChevrons !== false}
+            onClick={ () => this.toggleChevrons()}
           />
         </MenuItem>
         {/* <MenuItem style={buttonStyle}>

--- a/imports/client/ui/components/panelSelector/PanelSelector.jsx
+++ b/imports/client/ui/components/panelSelector/PanelSelector.jsx
@@ -13,7 +13,7 @@ const buttonStyle = {
   color:'#F2EFE9 !important'
 }
 
-@ui({ state: { showChevrons: true } })
+@ui({ key: 'PanelSettings', state: { showChevrons: true } })
 export default class PanelSelector extends React.Component {
 
   static propTypes = {
@@ -133,15 +133,6 @@ export default class PanelSelector extends React.Component {
             checked={legendVisible}
             //disabled={!legendVisible}
             onClick={ () => this.toggleLegend()}
-          />
-        </MenuItem>
-        <MenuItem style={buttonStyle}>
-          <Checkbox
-            label={'Chevrons'}
-            labelStyle={{backgroundColor: 'rgba(69,90,100 ,0.9)',
-            color:'#F2EFE9',}}
-            checked={showChevrons !== false}
-            onClick={ () => this.toggleChevrons()}
           />
         </MenuItem>
         {/* <MenuItem style={buttonStyle}>

--- a/imports/client/ui/components/panelSelector/PanelSelector.jsx
+++ b/imports/client/ui/components/panelSelector/PanelSelector.jsx
@@ -108,11 +108,17 @@ export default class PanelSelector extends React.Component {
             onClick={ () => this.toggleGeo()}
           />
         </MenuItem>
-        <MenuItem style={buttonStyle}>
+        <MenuItem style={{...buttonStyle, paddingLeft: 48, paddingTop: 6, paddingBottom: 6}}>
           <Checkbox
             label={'Chevrons'}
-            labelStyle={{backgroundColor: 'rgba(69,90,100 ,0.9)',
-            color:'#F2EFE9',}}
+            style={{ marginLeft: 0 }}
+            labelStyle={{
+              backgroundColor: 'rgba(69,90,100 ,0.9)',
+              color:'#F2EFE9',
+              fontSize: 12,
+              lineHeight: '16px'
+            }}
+            iconStyle={{ transform: 'scale(0.85)', transformOrigin: 'left center' }}
             checked={showChevrons !== false}
             onClick={ () => this.toggleChevrons()}
           />

--- a/imports/client/ui/components/panelSelector/PanelSelector.jsx
+++ b/imports/client/ui/components/panelSelector/PanelSelector.jsx
@@ -13,7 +13,7 @@ const buttonStyle = {
   color:'#F2EFE9 !important'
 }
 
-@ui()
+@ui({ state: { showChevrons: true } })
 export default class PanelSelector extends React.Component {
 
   static propTypes = {


### PR DESCRIPTION
Adds Chevrons toggle with proper redraw: split edges with chevrons ON; direct lines OFF.
Forces full layer remount on toggle to guarantee refresh on /topograms/:id.
Persists toggle in localStorage and broadcasts event to map.
Panel: de-duplicated Chevrons entry, made it a sub-option of Geo with smaller footprint and tighter spacing.
Map: smaller chevron boxes with larger glyphs, minimized padding, improved baseline and slight upward nudge for alignment; overlap stacking preserved.
Includes keys on layers to avoid stale render and ensure consistent behavior across routes.
