### PR TITLE
Modernize UI stack, stabilize CI, default JSON API, and fix Geo map selection

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -74,7 +74,7 @@ Phase 1: Remove hard legacy constraints on 1.4.4.6 (new prep branch)
 1) RESTivus replacement
    - Replace Restivus endpoints with `simple:json-routes` (JsonRoutes) or native `webapp` handlers.
    - Keep routes and handlers equivalent; leave old code in comments for reference.
-  - 2025-09-21: Implemented a feature-flagged JsonRoutes scaffold (default remains Restivus). Enable with `USE_JSONROUTES=1` or `Meteor.settings.public.useJsonRoutes = true`.
+  - 2025-09-21: Implemented a feature-flagged JsonRoutes scaffold (initially optional; later made default with native WebApp handlers).
   - Added minimal server tests for `/api`, `/api/topogramsPublic`, and a protected route auth check; added an authenticated POST `/api/topograms` test using `X-User-Id` and `X-Auth-Token` headers.
   - Refactored tests to avoid the deprecated `request` library (which pulled in `tough-cookie`/`psl` causing syntax errors). Switched to Node's built-in `http` client.
 
@@ -90,10 +90,9 @@ Phase 1: Remove hard legacy constraints on 1.4.4.6 (new prep branch)
 
 Run syntax (dev/test) on 1.4.4.6
 
-Server with external Mongo and JSON API enabled:
+Server with external Mongo (JSON API is enabled by default):
 
 ```sh
-USE_JSONROUTES=1 \
 MONGO_URL=mongodb://localhost:27017/Bandstour_results_meteor \
 ROOT_URL=http://localhost:3000 \
 meteor --port 3000
@@ -102,7 +101,6 @@ meteor --port 3000
 Full-app server tests (headless), against external Mongo:
 
 ```sh
-USE_JSONROUTES=1 \
 MONGO_URL=mongodb://localhost:27017/Bandstour_results_meteor \
 ROOT_URL=http://localhost:3010 \
 meteor test --once --full-app --driver-package dispatch:mocha --port 3010
@@ -128,8 +126,8 @@ New auth helpers (for end-to-end testing):
 Quick smoke (requires Mongo 4.4 at 27018):
 
 ```sh
-# Start
-USE_JSONROUTES=1 API_DEBUG=1 \
+# Start (API default; probe mode is optional)
+API_DEBUG=1 \
 MONGO_URL=mongodb://localhost:27018/Bandstour_results_meteor \
 ROOT_URL=http://localhost:3020 meteor --port 3020
 
@@ -207,7 +205,7 @@ Steps performed:
 5) Point the app to the new Mongo
 - Use: `MONGO_URL=mongodb://localhost:27018/Bandstour_results_meteor`.
 - In upgrade-probe mode (Meteor 2.x), start example:
-  - `UPGRADE_PROBE=1 USE_JSONROUTES=0 ROOT_URL=http://localhost:3020 meteor --port 3020`.
+  - `UPGRADE_PROBE=1 ROOT_URL=http://localhost:3020 meteor --port 3020`.
 
 6) Rollback / switch back
 - To revert to old DB, change MONGO_URL to `mongodb://localhost:27017/Bandstour_results_meteor` and ensure the old container `mongodb-32` is running.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ Quick start (development):
 git clone https://github.com/ungentilgarcon/topo25.git
 cd topo25/topogram
 meteor npm install
-# Optional: use a local MongoDB and enable JSON API endpoints
+# Optional: use a local MongoDB (JSON API is enabled by default)
 export MONGO_URL='mongodb://localhost:27018/Bandstour_results_meteor'
-export USE_JSONROUTES=1
 export ROOT_URL='http://localhost:3020'
 meteor --port 3020
 ```
@@ -55,7 +54,7 @@ lsof -ti :3024 | xargs -r kill -9
 Then relaunch Meteor on the same port in one line:
 
 ```sh
-PORT=3024 ROOT_URL=http://localhost:3024 MONGO_URL='mongodb://127.0.0.1:27018/Bandstour_results_meteor' USE_JSONROUTES=1 UPGRADE_PROBE=0 meteor --port 3024
+PORT=3024 ROOT_URL=http://localhost:3024 MONGO_URL='mongodb://127.0.0.1:27018/Bandstour_results_meteor' meteor --port 3024
 ```
 
 
@@ -90,9 +89,9 @@ All the docs will be built in the `.docs/` folder.
 
     gulp doc
 
-### JSON API (optional)
+### JSON API
 
-This fork exposes a lightweight JSON API for basic operations (auth, listing public topograms, and CRUD for topograms/nodes/edges). The API is disabled by default and can be enabled by setting `USE_JSONROUTES=1` at runtime.
+This fork exposes a lightweight JSON API for basic operations (auth, listing public topograms, and CRUD for topograms/nodes/edges). The API is enabled by default. To temporarily disable all custom API wiring during upgrade probes, start with `UPGRADE_PROBE=1`.
 
 - Docs: docs/API.md
 - Quick probe: `curl http://localhost:3020/api/whoami`

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,6 @@
 # JSON API
 
-The BandsTour fork exposes optional JSON endpoints for simple automation (auth, listing public resources, and CRUD for topograms/nodes/edges).
-
-Enable by setting `USE_JSONROUTES=1` when starting Meteor.
+The BandsTour fork exposes JSON endpoints for simple automation (auth, listing public resources, and CRUD for topograms/nodes/edges). The JSON API is enabled by default; to temporarily disable all custom endpoints during upgrade probes, start the app with `UPGRADE_PROBE=1`.
 
 Base URL: `${ROOT_URL}/api`
 

--- a/docs/Quickstart.md
+++ b/docs/Quickstart.md
@@ -23,11 +23,10 @@ meteor --port 3020
 
 Open http://localhost:3020
 
-## Run with JSON API enabled and external MongoDB
+## Run with external MongoDB (JSON API is enabled by default)
 
 ```
 export MONGO_URL='mongodb://localhost:27018/Bandstour_results_meteor'
-export USE_JSONROUTES=1
 export ROOT_URL='http://localhost:3020'
 meteor --port 3020
 ```
@@ -49,4 +48,4 @@ npm run lint
 
 ## Troubleshooting
 - If Meteor warns about peer deps, install the suggested packages or re-run `meteor npm install`.
-- If JSON API routes return 404, ensure `USE_JSONROUTES=1` is set and see `imports/endpoints/api-jsonroutes.js`.
+- If JSON API routes return 404, check logs for "Failed to initialize JSON API". During upgrade probes, the API is intentionally replaced by a minimal health route when `UPGRADE_PROBE=1` is set.

--- a/docs/migration-ui-react.md
+++ b/docs/migration-ui-react.md
@@ -38,15 +38,15 @@ This document tracks the ongoing React + MUI modernization for the Meteor app.
 
 - App runs under React 18 + MUI v5 via the compat layer.
 - Legacy warnings from `react-router@3` and `react-intl@2` are expected and non-blocking.
-- UI init loops eliminated; startup under USE_JSONROUTES/MONGO_URL is stable.
+- UI init loops eliminated; startup with external Mongo is stable; JSON API is enabled by default.
 
 ## How to run (local Meteor; no Docker)
 
-- JSON routes dev (Mongo on port 27018, recommended):
-  - `USE_JSONROUTES=1 MONGO_URL=mongodb://127.0.0.1:27018/topogram ROOT_URL=http://localhost:3020 meteor --port 3020`
+- Default dev (JSON API is enabled by default; Mongo on port 27018 recommended):
+  - `MONGO_URL=mongodb://127.0.0.1:27018/topogram ROOT_URL=http://localhost:3020 meteor --port 3020`
 
-- Probe mode:
-  - `UPGRADE_PROBE=1 USE_JSONROUTES=0 MONGO_URL=mongodb://127.0.0.1:27018/topogram ROOT_URL=http://localhost:3020 meteor --port 3020`
+- Probe mode (minimal health-only API):
+  - `UPGRADE_PROBE=1 MONGO_URL=mongodb://127.0.0.1:27018/topogram ROOT_URL=http://localhost:3020 meteor --port 3020`
 
 ## Known issues / limitations
 

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -186,7 +186,7 @@ export default class GeoEdges extends React.Component {
         segments.forEach((seg, sIdx) => {
           children.push(
             <Polyline
-              key={`edge-${i}-seg-${sIdx}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
+              key={`edge-${e.data && e.data.id != null ? e.data.id : i}-seg-${sIdx}-${e.data && e.data.selected ? 1 : 0}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
               opacity={"0.8"}
               color={color}
               weight={weight}
@@ -204,7 +204,7 @@ export default class GeoEdges extends React.Component {
           const hitWeight = Math.max(weight, 24)
           children.push(
             <Polyline
-              key={`edge-${i}-seg-${sIdx}-hit-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
+              key={`edge-${e.data && e.data.id != null ? e.data.id : i}-seg-${sIdx}-hit-${e.data && e.data.selected ? 1 : 0}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
               opacity={0.001}
               color={color}
               weight={hitWeight}

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -192,6 +192,7 @@ export default class GeoEdges extends React.Component {
               weight={weight}
               dashArray={dashArray}
               positions={seg}
+              bubblingMouseEvents={false}
               eventHandlers={{
                 click: () => { if (!isolateMode) handleClickGeoElement({ group: 'edge', el: e }) },
                 mousedown: () => { if (isolateMode) onFocusElement(e) },
@@ -234,7 +235,10 @@ export default class GeoEdges extends React.Component {
               key={`${ch.key}-${i}-${cIdx}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
               position={[lat, lng]}
               icon={ch.icon}
-              interactive={false}
+              interactive={true}
+              eventHandlers={{
+                click: () => { if (!isolateMode) handleClickGeoElement({ group: 'edge', el: e }) }
+              }}
             />
           )
         })

--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -192,9 +192,11 @@ export default class GeoEdges extends React.Component {
               weight={weight}
               dashArray={dashArray}
               positions={seg}
-              onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
-              onMouseDown={() => isolateMode ? onFocusElement(e) : null }
-              onMouseUp={()=> isolateMode ? onUnfocusElement() : null }
+              eventHandlers={{
+                click: () => { if (!isolateMode) handleClickGeoElement({ group: 'edge', el: e }) },
+                mousedown: () => { if (isolateMode) onFocusElement(e) },
+                mouseup: () => { if (isolateMode) onUnfocusElement() }
+              }}
             />
           )
           // Invisible hit area: larger weight, nearly transparent
@@ -207,9 +209,11 @@ export default class GeoEdges extends React.Component {
               weight={hitWeight}
               bubblingMouseEvents={false}
               positions={seg}
-              onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
-              onMouseDown={() => isolateMode ? onFocusElement(e) : null }
-              onMouseUp={()=> isolateMode ? onUnfocusElement() : null }
+              eventHandlers={{
+                click: () => { if (!isolateMode) handleClickGeoElement({ group: 'edge', el: e }) },
+                mousedown: () => { if (isolateMode) onFocusElement(e) },
+                mouseup: () => { if (isolateMode) onUnfocusElement() }
+              }}
             />
           )
         })
@@ -230,8 +234,7 @@ export default class GeoEdges extends React.Component {
               key={`${ch.key}-${i}-${cIdx}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
               position={[lat, lng]}
               icon={ch.icon}
-              interactive={true}
-              onClick={() => !isolateMode ? handleClickGeoElement({ group : 'edge', el: e }) : null }
+              interactive={false}
             />
           )
         })

--- a/imports/client/ui/components/geoMap/GeoMap.css
+++ b/imports/client/ui/components/geoMap/GeoMap.css
@@ -66,3 +66,12 @@ div.leaflet-top:nth-child(1){  z-index: 10000 !important;
   transform: scale(1.25);
   transform-origin: center;
 }
+
+/* Force-selected node styling (higher precedence than inline updates) */
+.topo-node-selected.leaflet-interactive {
+  stroke: #EEFF41 !important;
+  stroke-opacity: 0.9 !important;
+  stroke-width: 3px !important;
+  fill: #EEFF41 !important;
+  fill-opacity: 0.85 !important;
+}

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -16,7 +16,9 @@ const MAP_DIV_ID = 'map'
 const divMapStyle = {
   position: 'fixed',
   top: '0',
-  zIndex : -1
+  // Ensure the map can receive pointer events
+  zIndex : 0,
+  pointerEvents: 'auto'
 }
 
 @ui()

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -167,6 +167,7 @@ class GeoMap extends React.Component {
             nodes.length ? (
               <Pane name="nodesPane" style={{ zIndex: 650 }}>
                 <GeoNodes
+                  key={`geonodes-${selectedNodeIds.size}`}
                   nodes={nodes}
                   isolateMode={isolateMode}
                   handleClickGeoElement={(e) => this.handleClickGeoElement(e)}

--- a/imports/client/ui/components/geoMap/GeoNodes.jsx
+++ b/imports/client/ui/components/geoMap/GeoNodes.jsx
@@ -31,24 +31,11 @@ export default class GeoNodes extends React.Component {
           center={n.coords}
           opacity={"0.8"}
           color={n.data.selected ? 'yellow' : n.data.color ? n.data.color : 'steelblue'}
-          onClick={() => !isolateMode ?
-            handleClickGeoElement({
-              group : 'node',
-              el: n
-            })
-            :
-            null
-          }
-          onMouseDown={() => isolateMode ?
-            onFocusElement(n)
-            :
-            null
-          }
-          onMouseUp={()=> isolateMode ?
-            onUnfocusElement()
-            :
-            null
-          }
+          eventHandlers={{
+            click: () => { if (!isolateMode) handleClickGeoElement({ group: 'node', el: n }) },
+            mousedown: () => { if (isolateMode) onFocusElement(n) },
+            mouseup: () => { if (isolateMode) onUnfocusElement() }
+          }}
         />
       )
     })

--- a/imports/endpoints/api-jsonroutes.js
+++ b/imports/endpoints/api-jsonroutes.js
@@ -1,8 +1,6 @@
 /*
   WebApp-based API scaffold: Non-destructive alternative to Restivus/JsonRoutes
-  Enabled via:
-    - Meteor.settings.public.useJsonRoutes = true
-    - or env USE_JSONROUTES=1
+  Default: Enabled by default. To temporarily disable during upgrade probes, set env UPGRADE_PROBE=1.
   Note: Mirrors a subset of existing endpoints.
 */
 

--- a/imports/endpoints/index.js
+++ b/imports/endpoints/index.js
@@ -3,6 +3,7 @@ import { Accounts } from 'meteor/accounts-base'
 
 // Feature flags
 // - UPGRADE_PROBE: skip API wiring and expose only a minimal health endpoint
+//   JSON API is enabled by default when not in probe mode; no USE_JSONROUTES env is required.
 const upgradeProbe = (typeof process !== 'undefined' && process.env && process.env.UPGRADE_PROBE === '1')
 
 // In upgrade-probe mode, define only a tiny health route using WebApp and bail out

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "i18n:extract": "formatjs extract 'imports/**/*.{js,jsx,ts,tsx}' --ignore='**/*.test.*' --out-file .i18n/extracted/messages.json --format simple",
     "i18n:merge": "node ./.scripts/merge-intl.js",
     "i18n:update": "npm run i18n:extract && npm run i18n:merge",
-    "dev:probe": "UPGRADE_PROBE=1 USE_JSONROUTES=0 MONGO_URL=mongodb://localhost:27018/Bandstour_results_meteor ROOT_URL=http://localhost:3020 meteor --port 3020",
-    "dev:jsonroutes": "UPGRADE_PROBE=0 USE_JSONROUTES=1 MONGO_URL=mongodb://localhost:27018/Bandstour_results_meteor ROOT_URL=http://localhost:3020 meteor --port 3020"
+    "dev": "MONGO_URL=mongodb://localhost:27018/Bandstour_results_meteor ROOT_URL=http://localhost:3020 meteor --port 3020",
+    "dev:probe": "UPGRADE_PROBE=1 MONGO_URL=mongodb://localhost:27018/Bandstour_results_meteor ROOT_URL=http://localhost:3020 meteor --port 3020"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary

Modernizes the app (React 18, MUI v5, Router v6), stabilizes markdown/i18n, sets JSON API default-on, and fixes Geo map selection/painting regressions.
Highlights

Frontend
React 18, MUI v5, react-router-dom v6
react-leaflet v4 + Leaflet 1.9; restored node/edge click and selection
react-intl v6 + @formatjs/cli
Markdown stack pinned: react-markdown 8, remark-gfm 3, unified 10 (fixes “devlop” error)
CI/Repo
GitHub Actions for Lint/Test/Audit; branch protection ready
Server/API
JSON API default-on with native WebApp handlers
UPGRADE_PROBE=1 for health-only mode when needed
Geo Map
Nodes and edges selectable; fluorescent yellow repaint
Chevron clicks select and repaint corresponding edge
Selection synchronized across geo, network, and charts
Notable code

imports/client/ui/components/geoMap
GeoMap.jsx: selection derivation from UI.selectedElements; remount key tweak
GeoNodes.jsx: v4 eventHandlers; disabled bubbling; direct CircleMarker styling; selected CSS class for reliable repaint
GeoEdges.jsx: v4 eventHandlers; disabled bubbling; chevrons select/repaint
GeoMap.css: .topo-node-selected with strong yellow override
Migration notes

Router v6 routes/hooks, MUI v5 packages/theme, react-intl v6 provider/messages, react-leaflet v4 eventHandlers/pathOptions
Verification

Geo map clicks repaint yellow; charts/network selections sync; public topograms render; markdown works without “devlop”; API responds by default; UPGRADE_PROBE=1 limits to health checks