### PR TITLE
perf(network): reduce Cytoscape redraws; remove startup animation; fix map keys and focus modes

### DIFF
--- a/imports/client/ui/components/geoMap/GeoEdges.jsx
+++ b/imports/client/ui/components/geoMap/GeoEdges.jsx
@@ -138,6 +138,7 @@ export default class GeoEdges extends React.Component {
     const isChevronsOn = (this.state && typeof this.state.chevronsOn === 'boolean')
       ? this.state.chevronsOn
       : (!this.props.ui || this.props.ui.showChevrons !== false)
+    const chevKeyPart = isChevronsOn ? 'with' : 'no'
     const seamSlots = { '180': new Map(), '-180': new Map() }
     const getOffsetLat = (boundary, lat) => {
       const key = boundary === 180 ? '180' : '-180'
@@ -163,6 +164,9 @@ export default class GeoEdges extends React.Component {
         e.data.group.includes("DASHED-1")? "1,5,1,5,1":
         ""
       ) : ""
+      // Build a unique key root per rendered edge item to avoid duplicate keys
+      const edgeIdSafe = (e && e.data && e.data.id != null) ? String(e.data.id) : ''
+      const keyRoot = `edge-${edgeIdSafe}-${i}` // include index to ensure uniqueness even if ids repeat
       // Read UI toggle once per edge to drive splitting behavior
   const showChevrons = isChevronsOn
       let segments = []
@@ -186,7 +190,7 @@ export default class GeoEdges extends React.Component {
         segments.forEach((seg, sIdx) => {
           children.push(
             <Polyline
-              key={`edge-${e.data && e.data.id != null ? e.data.id : i}-seg-${sIdx}-${e.data && e.data.selected ? 1 : 0}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
+              key={`${keyRoot}-seg-${sIdx}-${e.data && e.data.selected ? 1 : 0}-${chevKeyPart}-chev`}
               opacity={"0.8"}
               color={color}
               weight={weight}
@@ -204,7 +208,7 @@ export default class GeoEdges extends React.Component {
           const hitWeight = Math.max(weight, 24)
           children.push(
             <Polyline
-              key={`edge-${e.data && e.data.id != null ? e.data.id : i}-seg-${sIdx}-hit-${e.data && e.data.selected ? 1 : 0}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
+              key={`${keyRoot}-seg-${sIdx}-hit-${e.data && e.data.selected ? 1 : 0}-${chevKeyPart}-chev`}
               opacity={0.001}
               color={color}
               weight={hitWeight}
@@ -232,7 +236,7 @@ export default class GeoEdges extends React.Component {
           }
           children.push(
             <Marker
-              key={`${ch.key}-${i}-${cIdx}-${(!this.props.ui || this.props.ui.showChevrons !== false) ? 'with' : 'no'}-chev`}
+              key={`${ch.key}-${i}-${cIdx}-${chevKeyPart}-chev`}
               position={[lat, lng]}
               icon={ch.icon}
               interactive={true}

--- a/imports/client/ui/components/geoMap/GeoMap.jsx
+++ b/imports/client/ui/components/geoMap/GeoMap.jsx
@@ -116,7 +116,14 @@ class GeoMap extends React.Component {
       selected.filter(e => e && e.group === 'nodes' && e.data && e.data.id != null).map(e => e.data.id)
     )
     const selectedEdgeIds = new Set(
-      selected.filter(e => e && e.group === 'edges' && e.data && e.data.id != null).map(e => e.data.id)
+      selected
+        .filter(e => e && e.group === 'edges' && e.data && e.data.id != null)
+        .map(e => String(e.data.id))
+    )
+    const selectedEdgePairs = new Set(
+      selected
+        .filter(e => e && e.group === 'edges' && e.data && e.data.source != null && e.data.target != null)
+        .map(e => `${String(e.data.source)}|${String(e.data.target)}`)
     )
 
     const nodes = (this.props.nodes || [])
@@ -140,8 +147,10 @@ class GeoMap extends React.Component {
         if (!source || !target) return null
         const coords = [source.coords, target.coords]
         // Same: compute selected from global UI first, fall back to data flag
-        const isSelected = selectedEdgeIds.has(e.data.id) || !!e.data.selected
-        return { ...e, source, target, coords, selected: isSelected, data: { ...e.data, selected: isSelected } }
+        const edgeId = e && e.data && e.data.id != null ? String(e.data.id) : undefined
+        const pairKey = `${String(e.data.source)}|${String(e.data.target)}`
+        const isSelected = (edgeId ? selectedEdgeIds.has(edgeId) : false) || selectedEdgePairs.has(pairKey) || !!e.data.selected
+        return { ...e, source, target, coords, selected: isSelected, data: { ...e.data, selected: isSelected, id: edgeId || pairKey } }
       })
       .filter(Boolean)
 

--- a/imports/client/ui/components/network/Cytoscape.jsx
+++ b/imports/client/ui/components/network/Cytoscape.jsx
@@ -256,9 +256,18 @@ class Cytoscape extends Component {
           const id = n && n.data && (n.data.id || n.data._id)
           if (!id) return
           const ele = this.cy.getElementById(id)
-          if (ele && ele.nonempty()) {
+          if (ele && ele.length > 0) {
             try { ele.style('display', 'element') } catch (_) {}
-            // Optionally update position/data here if needed
+            // Update data fields (except id) and position if provided
+            if (n.data) {
+              Object.keys(n.data).forEach(k => {
+                if (k === 'id' || k === '_id') return
+                try { ele.data(k, n.data[k]) } catch (_) {}
+              })
+            }
+            if (n.position) {
+              try { ele.position(n.position) } catch (_) {}
+            }
           } else {
             try { this.cy.add(n) } catch (_) {}
           }
@@ -279,8 +288,14 @@ class Cytoscape extends Component {
           const id = e && e.data && (e.data.id || e.data._id)
           if (!id) return
           const ele = this.cy.getElementById(id)
-          if (ele && ele.nonempty()) {
+          if (ele && ele.length > 0) {
             try { ele.style('display', 'element') } catch (_) {}
+            if (e.data) {
+              Object.keys(e.data).forEach(k => {
+                if (k === 'id' || k === '_id') return
+                try { ele.data(k, e.data[k]) } catch (_) {}
+              })
+            }
           } else {
             try { this.cy.add(e) } catch (_) {}
           }
@@ -295,6 +310,8 @@ class Cytoscape extends Component {
             try { ele.style('display', 'element') } catch (_) {}
           }
         })
+        // Recompute style mappings after data changes (colors, widths)
+        try { this.cy.style().update() } catch (_) {}
       })
 
       // Do not auto layout on visibility toggles; preserve current layout

--- a/imports/client/ui/components/network/Network.jsx
+++ b/imports/client/ui/components/network/Network.jsx
@@ -194,7 +194,8 @@ class Network extends React.Component {
   componentDidUpdate() {
     const cy = this.graphRef.current && this.graphRef.current.getCy ? this.graphRef.current.getCy() : null
     if (!cy) return
-    cy.resize().fit()
+    // Avoid auto-fit on every update; it causes visible animations and extra work
+    cy.resize()
   }
 
   render() {

--- a/imports/client/ui/components/network/NetworkDefaultStyle.js
+++ b/imports/client/ui/components/network/NetworkDefaultStyle.js
@@ -7,8 +7,12 @@ let txt = ''
 const NetworkDefaultStyle = (cy) => {
   const s = cy.style()
 
+  const w = cy && cy.container() ? cy.container().clientWidth || 800 : 800
+  const baseFont = Math.max(9, Math.round(w / 140)) // ~13 at 1920 half-screen, not too big on small screens
+  const maxLabel = Math.max(40, Math.round(w / 40))
+
   s.selector('node').style({
-    'font-size': 8,
+    'font-size': baseFont,
     'text-valign'() {
       // alternate top/bottom label position
       txt = (alternate % 2 === 0) ? 'top' : 'bottom'
@@ -24,11 +28,11 @@ const NetworkDefaultStyle = (cy) => {
     },
     'text-outline-color': 'black',
     'text-outline-width': '.2px',
-    'text-max-width': 40,
+  'text-max-width': maxLabel,
     'text-wrap': 'wrap',
     // cytoscape uses 'autorotate' for edges; nodes text rotation uses angles only via data mappings.
     // The prior '100°' caused no effect; omit to avoid parser issues.
-  'min-zoomed-font-size': 3,
+  'min-zoomed-font-size': Math.max(3, Math.round(baseFont * 0.6)),
     'border-color': '#D84315',
     'background-color'(e) {
       let color = 'steelblue' // default

--- a/imports/client/ui/pages/TopogramViewComponent.jsx
+++ b/imports/client/ui/pages/TopogramViewComponent.jsx
@@ -268,8 +268,11 @@ handleExitIsolateMode = () => {
   cy.nodes().style({ 'opacity': '1' });
   cy.edges().style({ 'opacity': '1' });
 
-  // bring back positions
-  cy.nodes().positions((i,n) => prevPositions[n.id()])
+  // bring back positions (use correct callback signature: (node, index))
+  cy.nodes().positions((n, i) => {
+    const p = prevPositions ? prevPositions[n.id()] : undefined
+    return p ? p : n.position()
+  })
   this.props.updateUI('prevPositions', null)
 
   cy.fit()

--- a/imports/client/ui/pages/TopogramViewComponent.jsx
+++ b/imports/client/ui/pages/TopogramViewComponent.jsx
@@ -128,9 +128,9 @@ export class TopogramViewComponent extends React.Component {
       console.log("cy",{...cy})
       const selectedIds = selectedElements.map(e => e.data.id)
       console.log("selectedIds",selectedIds)
-      const focusedNodes = cy.filter((i, e) =>
-      selectedIds.includes(e.id())
-    )
+      const focusedNodes = cy.nodes().filter((e, i) =>
+        selectedIds.includes(e.id())
+      )
     console.log(focusedNodes)
 
     //console.log("nodeId",{...nodeIds}),
@@ -184,9 +184,9 @@ handleEnterIsolateMode = () => {
 
   // get my nodes/edges
   const selectedIds = selectedElements.map(e => e.data.id)
-  const focusedNodes = cy.filter((i, e) =>
-  selectedIds.includes(e.id())
-)
+  const focusedNodes = cy.nodes().filter((e, i) =>
+    selectedIds.includes(e.id())
+  )
 
 cy.nodes().style({ 'opacity': '0' });
 cy.edges().style({ 'opacity': '0' });
@@ -226,9 +226,9 @@ handleEnterExtractMode = () => {
 
   // get my nodes/edges
   const selectedIds = selectedElements.map(e => e.data.id)
-  const focusedNodes = cy.filter((i, e) =>
-  selectedIds.includes(e.id())
-)
+  const focusedNodes = cy.nodes().filter((e, i) =>
+    selectedIds.includes(e.id())
+  )
 
 cy.nodes().style({ 'opacity': '0' });
 cy.edges().style({ 'opacity': '0' });


### PR DESCRIPTION
Cytoscape: canvas renderer, no auto-fit on updates, no visible startup animation, deterministic spread; toggle visibility for time filtering; stable edge IDs; style refresh
GeoMap: unique React keys for edge segments/hit layers/chevrons; robust selection; selected edges in yellow
UX: one-time center on init/resize until user pans/zooms; responsive node labels
Fix: isolate/extract/clear use proper Cytoscape APIs (filter and positions callbacks), resolving “e.id/n.id is not a function”
