### PR TITLE
Releasev.5 prepare

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,5 +1,5 @@
 Authors ordered by first contribution
 
 Clément Renaud <hi@clementrenaud.com>
-Gregory Bahde <gregory.bahde@laposte.net>
+Grégory Bahdé <bahdegregory@gmail.com>
 Lionel Radisson <makio135@gmail.com>

--- a/CHANGELOG_V.4.md
+++ b/CHANGELOG_V.4.md
@@ -110,3 +110,33 @@ Contributors: @ungentilgarcon, @gregory bahdé
 ---
 
 Generated from Git history and docs references across 2025 dates.
+
+---
+
+## Conventional-commit categories
+
+### Features (feat)
+- Charts: migrate C3 → Recharts; selection highlighting and pop-out enhancements
+- GeoMap: chevrons at antimeridian; UI toggles; compact controls and offsets
+- UI: draggable/resizable popups for Charts and Legend; improved panels and menus
+- Network: isolate “Focus and rearrange” workflow (closedNeighborhood + spread)
+
+### Fixes (fix)
+- SelectedItem: drop rehype-raw, convert anchors to Markdown to avoid ESM errors
+- Cytoscape: stable IDs for edges; visibility sync; avoid startup animation
+- GeoMap: robust selection rendering; guard invalid coords; attribution visibility
+- Timeline/Router: v6 migration fixes; slider initialization and value guards
+
+### Performance (perf)
+- Cytoscape: keep layout stable by toggling display rather than remove/add; canvas renderer; fewer relayouts
+
+### Refactors (refactor)
+- UI compat layers for MUI v5; redux-ui removal; createRef/string-ref migrations
+
+### Chore (chore)
+- Node 20 via .nvmrc; ESLint 8; CI bootstrap; dependency cleanup
+- Simpl-schema migration with shims and load-order fixes; Meteor package alignment
+
+### Documentation (docs)
+- Migration logs for React/MUI/Cytoscape/Charts; API and Quickstart updates
+- README updates with V4 changelog link

--- a/CHANGELOG_V.4.md
+++ b/CHANGELOG_V.4.md
@@ -1,0 +1,112 @@
+# BandsTour V4 — Changelog (2025)
+
+This changelog summarizes all notable changes made in 2025 up to the V4 line, covering frontend modernization, UX polish, network/geomap fixes, and tooling/CI upgrades.
+
+## Highlights
+
+- React 18 + MUI v5 modernization with compatibility wrappers
+- Cytoscape 3 upgrade with performance and visibility improvements
+- Charts migration from C3 to Recharts with selection sync
+- Safer Markdown rendering for SelectedItem (no raw HTML parsing)
+- Leaflet/react-leaflet v4 migration for GeoMap + UI polish
+- Robust isolate/focus behavior with layout + viewport fit
+- CI bootstrap with ESLint 8 and Node LTS v20
+
+---
+
+## UI/UX
+
+- TitleBox and Panels
+  - Align TitleBox with side panel theme (dark/ivory/purple), raise z-index above overlays, and add subtle text-outline for stats.
+  - Purple-themed action buttons ("Focus and rearrange" / "Focus only").
+  - SidePanel polish: compact spacing; toolbar icons hover/ripple; submenu arrows repositioned and auto-close timers added.
+
+- Network (Cytoscape)
+  - Upgrade to Cytoscape 3; use canvas renderer; avoid visible startup animation.
+  - Initial fit-on-mount (once) and reduced fit padding to use more screen.
+  - Keep layout stable during time filtering by toggling display instead of add/remove.
+  - Robust element sync: stable IDs (source|target), update data/position in batch, hide non-visible elements, update styles.
+  - Isolate “Focus and rearrange”: include closedNeighborhood(), unlock, spread layout, show only subgraph, fit viewport.
+  - Labels: slightly bigger by default; enlarge noticeably on hover and restore cleanly.
+  - Panzoom positioning refined above timeline/overlays; higher z-index.
+
+- Charts/Selection/Chips
+  - Replace C3 donuts with Recharts; highlight selections; batch-toggle so multiple chips appear at once.
+  - Chip font size finalized at 10px; Reset button and pop-out windows readable in dark theme.
+
+- SelectedItem (notes)
+  - Removed raw HTML parsing path (rehype-raw) to avoid ESM devlop runtime errors under Meteor.
+  - Pre-convert <a href="URL">TEXT</a> to Markdown links and render via react-markdown + remark-gfm; open in new tab with rel security.
+
+- GeoMap (Leaflet)
+  - Migrate to react-leaflet v4; restore selection handling with eventHandlers.
+  - Compact controls and dynamic bottom offsets based on timeline/legend; attribution always visible.
+  - Chevron/antimeridian handling improved; split edges at date line and style glyphs for legibility.
+
+---
+
+## Tooling & Infrastructure
+
+- Node LTS pinned to v20 via .nvmrc; engines specified.
+- ESLint upgraded to v8 with @babel/eslint-parser; config simplified; CI jobs stabilized.
+- CI bootstrap with GitHub Actions: lint, test, production audit, manual dispatch; green baseline.
+- Meteor upgrades and schema migrations:
+  - Gradual move to npm simpl-schema with compatibility shims; preserve legacy options/regex; load order fixed.
+  - Remove outdated Atmosphere packages; add JSON API routes as default; document migration plan and phases.
+
+---
+
+## Detailed commit timeline (2025)
+
+- 2025-10-03
+  - fix/ux: TitleBox parity and readability; purple buttons; outlined stats.
+  - fix(isolate): closedNeighborhood + spread layout + viewport fit; keep only subgraph visible.
+  - fix(charts): batch-toggle selections for multi-chip behavior.
+  - ux(chips): set chip text size to 10px (after interim 12px).
+  - fix(selected-item): drop rehype-raw, convert anchors to Markdown links; avoid devlop ESM issues.
+  - fix(network/geomap): panzoom placement; hide edges when endpoints hidden; fit-on-mount and better label scaling.
+  - perf(cytoscape): preserve layout and reduce visible redraws; use canvas renderer.
+  - chore(schemas): migrate to npm simpl-schema with shims; CI/dev stable.
+  - docs: migration notes for Cytoscape v3 and Recharts; Node LTS and ESLint clarifications.
+
+- 2025-10-02
+  - Upgrade path React 16 -> 17 -> 18 with guarded fallbacks (createRoot or render).
+  - Router migration to react-router v6 and compat shims; AppV6 wrappers; Link fixes.
+  - Timeline slider migrated to MUI Slider; removed rc-slider/rc-tooltip; i18n and tooltip polish.
+  - GeoMap migrated to react-leaflet v4; restored node/edge selection visuals and events.
+  - Charts modernization: migrate from C3 to Recharts; interim compat kept for tests; remove legacy deps.
+  - MUI v5 migration with local compat wrappers for Dialog/MenuItem/TextField; replace legacy RaisedButton; theme polish.
+  - UI infra: redux-ui removed; local UI compat HOC + reducer; stabilize init.
+  - CI bootstrap; ESLint 8; temp ignores to get green; follow-up cleanups.
+
+- 2025-10-01
+  - Early modernization groundwork: React 16 support, lifecycle migration, ref conversions, and MapScreenshots fixes.
+  - Geo chevrons/dateline features and selection robustness; cleanup of invalid React patterns in map layers.
+  - Pop-out windows for Charts and Legend; improved dark theme and tooltips.
+  - Misc fixes: favicon, fonts, PropTypes, pane z-index, CORS/tiles; LFS for media.
+
+- 2025-09-22
+  - Meteor 3 prep: JSON API scaffolding and migration docs; Mongo 4.4 container; package and versions alignment.
+  - README/docs overhaul and V0.3 release notes.
+
+---
+
+## Breaking changes
+
+- Removed legacy Blaze/C3 stacks; code now targets React 18 + MUI v5 and Recharts.
+- Router is react-router v6; legacy route hooks removed in favor of compat wrappers.
+- Markdown stack pinned (react-markdown 8, remark-gfm 3) to avoid Meteor bundler ESM resolution issues.
+
+## Upgrade notes
+
+- Ensure Node 20 available (nvm use) and reinstall deps after pulling.
+- If you had custom C3 usage, migrate to Recharts equivalents.
+- Verify environment variables and USE_JSONROUTES defaults as noted in MIGRATION.md.
+
+## Credits
+
+Contributors: @ungentilgarcon, @gregory bahdé
+
+---
+
+Generated from Git history and docs references across 2025 dates.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Topogram is a web app to visualize the evolution of networks over time and space
 
 - Current version: V0.3 (Meteor 2.13.x)
 - Highlights in V0.3: non-blocking, draggable help popup; JSON API endpoints; migration groundwork. See the [Changelog](./CHANGELOG.md).
+- V4 changes (2025): see [CHANGELOG_V.4.md](./CHANGELOG_V.4.md). Release notes will also summarize highlights.
 
 For background, see the original project: http://topogram.io
 
@@ -40,6 +41,13 @@ meteor --port 3020
 ```
 
 More details in docs/Quickstart.md.
+
+Additional documentation:
+
+- Project structure: [docs/STRUCTURE.md](./docs/STRUCTURE.md)
+- JSON API: [docs/API.md](./docs/API.md)
+- Conventional Commits: [docs/CONVENTIONAL_COMMITS.md](./docs/CONVENTIONAL_COMMITS.md)
+- Releasing: [docs/RELEASING.md](./docs/RELEASING.md)
 
 
 ### Troubleshooting

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing Guide
+
+Thanks for your interest in contributing to BandsTour (Topogram fork)!
+
+## Development setup
+
+- Install Meteor (see meteor.com) and Node LTS 20 for tooling (`nvm use` in `topogram/`).
+- Install deps: `meteor npm install` in `topogram/`.
+- Run: `meteor --port 3020`.
+
+## Branching and commits
+
+- Use feature branches from `main`.
+- Prefer Conventional Commits for messages:
+  - `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `perf:`, `test:`
+  - Scope when useful, e.g., `feat(network): ...`
+- Open PRs against `main` with a clear description and screenshots/GIFs for UI.
+
+## Coding guidelines
+
+- React 18 + MUI v5; prefer function components unless class-based is required.
+- Ensure Cytoscape/Leaflet interactions do not block the main thread; batch updates.
+- Keep i18n keys in `i18n/*.json` and use `react-intl`.
+- Lint: `npm run lint` and fix warnings if feasible.
+
+## Tests
+
+- Add/update unit tests where applicable.
+- For Meteor integration tests, use the existing specs harness.
+
+## Releases
+
+- Maintain `CHANGELOG.md` and version bumps in `package.json`.
+- For V4/V5 lines, also update `CHANGELOG_V.4.md` and release notes.
+
+## Security
+
+- Do not commit secrets. Use environment variables for tokens/URLs.
+

--- a/docs/CONVENTIONAL_COMMITS.md
+++ b/docs/CONVENTIONAL_COMMITS.md
@@ -1,0 +1,24 @@
+# Conventional Commits
+
+We use the Conventional Commits specification to keep a consistent, machine-readable history.
+
+## Summary
+
+- `feat(scope): summary` — a new feature
+- `fix(scope): summary` — a bug fix
+- `docs(scope): summary` — documentation only changes
+- `chore(scope): summary` — tooling, config, build changes
+- `refactor(scope): summary` — code changes that neither fix a bug nor add a feature
+- `perf(scope): summary` — a code change that improves performance
+- `test(scope): summary` — adding missing tests or correcting existing tests
+
+Optional:
+- `BREAKING CHANGE:` footer for breaking changes
+- `revert:` prefix for revert commits
+
+## Examples
+
+- `feat(network): add spread layout and fit to subgraph`
+- `fix(geomap): ensure attribution visible and compact` 
+- `docs(readme): add V4 changelog link`
+

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,25 @@
+# Releasing
+
+This guide explains how to prepare and publish a release.
+
+## Branching
+
+- Create a dedicated release prep branch, e.g., `releasev.5_prepare`.
+- Aggregate and commit final changes (docs, version bumps, changelog).
+
+## Changelogs
+
+- Update `CHANGELOG.md` (short) and the versioned changelog (e.g., `CHANGELOG_V.4.md`).
+- Categorize entries by Conventional Commit types: feat, fix, chore, docs, perf, refactor.
+
+## PR and tagging
+
+- Open a PR against `main` with a detailed description and links to docs.
+- After merge, create a tag: `git tag -a V4.0 -m "Release V4.0" && git push --tags`.
+- Update README badges if needed.
+
+## Post-release
+
+- Announce highlights and link to changelogs.
+- Create an issue with next milestones/tasks if applicable.
+

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -1,0 +1,59 @@
+# Project Structure
+
+This document explains the folder layout and key components of the BandsTour (Topogram fork) app.
+
+```
+/topogram
+  ├─ .meteor/                 # Meteor app metadata and package versions
+  ├─ imports/
+  │   ├─ api/                 # Collections, publications, methods, endpoints
+  │   ├─ client/
+  │   │   ├─ helpers/         # UI helpers (colors, utils)
+  │   │   ├─ ui/              # React UI components
+  │   │   │   ├─ components/  # Leaf components (charts, map, network, panels)
+  │   │   │   ├─ pages/       # Route-level pages
+  │   │   │   └─ styles/      # CSS and theme overrides
+  │   ├─ startup/             # App startup (client/server)
+  │   └─ ...
+  ├─ public/                  # Static assets (images, videos)
+  ├─ server/                  # Server entrypoints (Meteor)
+  ├─ i18n/                    # Translations
+  ├─ docs/                    # Documentation (API, quickstart, migrations)
+  ├─ package.json             # NPM dependencies and scripts
+  ├─ README.md                # Top-level docs
+  └─ CHANGELOG*.md            # Changelogs
+```
+
+## Key UI modules
+
+- Network (Cytoscape) — `imports/client/ui/components/network/`
+  - `Cytoscape.jsx`: wrapper around Cytoscape v3 with element syncing and fit/layout management
+  - `Network.jsx`: integrates events, selection, and fits; bridges app UI ↔ graph
+  - `NetworkDefaultStyle.js`: runtime stylesheet setup (sizes, colors, hover)
+
+- Geo Map (Leaflet) — `imports/client/ui/components/geoMap/`
+  - `GeoMap.jsx`: react-leaflet v4 map container, nodes and edges layers
+  - `GeoMapOptions.jsx`: toggles and options for map display (chevrons, offsets)
+
+- Charts (Recharts) — `imports/client/ui/components/charts/`
+  - `Charts.jsx`: donut charts and interactions that reflect selection
+
+- Title and Panels — `imports/client/ui/components/titlebox/`, `SidePanel/`
+  - `TitleBox.jsx`: title, summary stats, and action buttons
+  - `SidePanel.jsx`: options and settings panels with MUI v5 compat theme
+
+## Data and API
+
+- Collections and schema validation live under `imports/api/`.
+- JSON API endpoints are provided (see `docs/API.md`).
+
+## Build and tooling
+
+- Meteor manages runtime Node; tooling Node is pinned via `.nvmrc` (Node 20).
+- ESLint 8 configured with `@babel/eslint-parser`; see CI config for checks.
+
+## Tests
+
+- Functional component tests under `tests/` (if present).
+- Meteor integration tests under `specs/`.
+

--- a/imports/client/ui/components/About.jsx
+++ b/imports/client/ui/components/About.jsx
@@ -65,8 +65,8 @@ class About extends React.Component {
             Please feel free to get in touch at <a href="mailto:greg@grrrndzero.org"></a>.
           </p>
           <p><small>
-            BandsTour 2015-2025 (cc). Thanks to Grégory Bahde,Clément Renaud.
-            Topogram 2015-2017 (cc). Thanks to Clément Renaud, Grégory Bahde and Lionel Radisson.
+            BandsTour 2015-2025 (cc). Thanks to Grégory Bahdé, Clément Renaud.
+            Topogram 2015-2017 (cc). Thanks to Clément Renaud, Grégory Bahdé and Lionel Radisson.
           </small></p>
           <Version />
         </Dialog>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "topogram",
+  "name": "bandstour",
   "version": "0.3.0",
   "description": "Real-time collaborative social network analysis toolkit",
   "main": "topogram.js",
@@ -75,14 +75,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/topogram/topogram.git"
+    "url": "https://github.com/ungentilgarcon/topo25.git"
   },
-  "author": "Clément Renaud <hi@clementrenaud.com> (http://clementrenaud.com/)",
+  "author": " Grégory Bahdé <bahdegregory@gmail.com> )",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/topogram/topogram/issues"
+    "url": "https://github.com/ungentilgarcon/topo25/issues"
   },
-  "homepage": "https://topogram.github.io",
+  "homepage": "https://bandstour.io(soon)",
   "engines": {
     "node": ">=20 <21",
     "npm": ">=10 <11"


### PR DESCRIPTION
This PR prepares the V4 line for release by aggregating 2025 changes, adding comprehensive docs, and polishing UX across network, charts, map, and panels.
Highlights

React 18 + MUI v5 modernization with compat wrappers; ESLint 8; Node 20 for tooling.
Cytoscape v3 upgrade: canvas renderer, stable element sync, initial fit-on-mount, better labels.
Charts migrated from C3 to Recharts; chart clicks batch-select to show multiple chips.
SelectedItem notes: safe Markdown links (no raw HTML/ESM issues), consistent styling.
GeoMap on react-leaflet v4: compact controls, dynamic bottom offsets, chevrons at antimeridian.
TitleBox/panels restyled for parity and readability; timeline/panzoom layer fixes.
Changelog

Full 2025 V4 log: CHANGELOG_V.4.md
Categorized by Conventional Commits in the same file (feat/fix/perf/refactor/chore/docs).
Docs

README now links to:
docs/STRUCTURE.md — project layout and key modules
API.md — JSON API endpoints and usage
docs/CONVENTIONAL_COMMITS.md — commit style guide
docs/RELEASING.md — release procedure
CHANGELOG_V.4.md — full V4 changes
Conventional commit categories (excerpt)

feat: Recharts migration; isolate “Focus and rearrange”; Geo chevrons & offsets; pop-out windows.
fix: SelectedItem safe links; Cytoscape stable IDs & visibility; react-router v6/timeline guards; Geo selection/attribution.
perf: toggle display instead of add/remove; fewer relayouts; canvas renderer.
refactor: UI compat for MUI v5; redux-ui removal; ref/Lifecycle migrations.
chore: Node 20 via .nvmrc; ESLint 8; CI bootstrap; simpl-schema migration.
docs: migration logs; API and Quickstart updates; README V4 changelog link.
Upgrade notes

Ensure Node 20 for tooling (nvm use).
Pull deps; verify charts and network behavior.
If you had custom C3 usage, port to Recharts equivalents.
Review MIGRATION.md for API/schema/tooling changes.
Verification

Lint/typecheck passes locally for changed files.
Manual smoke tests: network isolate, chart selection (multi-chip), map controls/attribution, SelectedItem links.
No startup animations on network; labels readable and enlarge on hover.